### PR TITLE
fix: remove socket.io

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,8 +187,9 @@ Console.prototype.start = function ConsoleStart() {
         self.browserConnected = true;
         self.emit('logJSON', '');
     });
-    this.utWss.start(this.httpServer.listener);
     this.utWss.registerPath('/status');
+    this.utWss.ignorePath('/socket.io/');
+    this.utWss.start(this.httpServer.listener);
 
     this.httpServer.start(function() {
         self.log.info && self.log.info('go to: ' + self.httpServer.info.uri + ' to access the debug console');

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 const Port = require('ut-bus/port');
 const Path = require('path');
 const util = require('util');
-const io = require('socket.io');
 const Hapi = require('hapi');
 const Inert = require('inert');
-const JSONStream = require('JSONStream');
 const UtWss = require('ut-port-httpserver/socketServer');
 const jwt = require('jsonwebtoken');
 const Boom = require('boom');
+const dgram = require('dgram');
+var ndjson = require('ndjson');
 var merge = require('lodash.merge');
 const _undefined = undefined;
 
@@ -15,8 +15,11 @@ function Console(config) {
     Port.apply(this, arguments);
     this.config = merge({
         id: 'debug_console',
+        exclusive: true,
+        host: 'localhost',
+        port: 30001,
         server: {
-            host: '127.0.0.1',
+            host: 'localhost',
             port: 30001,
             state: {
                 strictHeader: false
@@ -157,8 +160,7 @@ Console.prototype.start = function ConsoleStart() {
                 parse: true
             },
             handler: function(request, reply) {
-                request.payload.files.pipe(JSONStream.parse('*')).on('data', function(log) {
-                    // self.console.emit(log.timestamp ? 'logMessage' : 'logJSON', log);
+                request.payload.files.pipe(ndjson.parse('*')).on('data', function(log) {
                     self.emit('logJSON', log);
                 });
                 return reply('');
@@ -175,11 +177,20 @@ Console.prototype.start = function ConsoleStart() {
         }
     });
 
-    this.socket = io(this.httpServer.listener);
-    this.socket.of('/log').on('connection', function(socket) {
-        socket.on('log', function(msg) {
-            self.emit('logJSON', msg);
-        });
+    this.ldstream = ndjson.parse();
+    this.ldstream.on('data', msg => this.emit('logJSON', msg));
+
+    this.socket = dgram.createSocket('udp4');
+    this.socket.on('message', (msg, rinfo) => {
+        this.ldstream.write(msg);
+    });
+    this.socket.on('close', () => {
+        this.ldstream = _undefined;
+    });
+    this.socket.bind({
+        address: this.config.host,
+        port: this.config.port,
+        exclusive: this.config.exclusive
     });
 
     this.utWss = new UtWss({log: this.log}, this.config);
@@ -188,7 +199,6 @@ Console.prototype.start = function ConsoleStart() {
         self.emit('logJSON', '');
     });
     this.utWss.registerPath('/status');
-    this.utWss.ignorePath('/socket.io/');
     this.utWss.start(this.httpServer.listener);
 
     this.httpServer.start(function() {
@@ -213,7 +223,7 @@ Console.prototype.emit = function emit(type, msg) {
 Console.prototype.stop = function ConsoleStop() {
     Port.prototype.stop.apply(this, arguments);
     // cleanup
-    this.socket.close('Console socket closed');
+    this.socket.close();
     this.httpServer.stop();
     if (this.db && this.db.close) {
         this.db.close();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-port-console",
-  "version": "6.4.0-rc.0",
+  "version": "6.4.0-rc.1",
   "dependencies": {
     "hapi": "16.0.2",
     "inert": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-port-console",
-  "version": "6.3.8",
+  "version": "6.4.0-rc.0",
   "dependencies": {
     "JSONStream": "1.3.0",
     "hapi": "16.0.2",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,13 @@
   "name": "ut-port-console",
   "version": "6.4.0-rc.0",
   "dependencies": {
-    "JSONStream": "1.3.0",
     "hapi": "16.0.2",
     "inert": "4.0.4",
     "boom": "5.1.0",
     "lodash.merge": "4.6.0",
     "lodash.assign": "4.2.0",
     "jsonwebtoken": "7.4.1",
-    "socket.io": "2.0.3",
+    "ndjson": "1.5.0",
     "ut-port-httpserver": "^8.12.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Sending packets through socket.io is not good, as exposes this in HTTP server without particular reason. Better listen on simple UDP socket. If we want to collect also front end logs, best is to send them through the wss socket, where we can be checking for proper jwt.

BREAKING CHANGE: log messages should be sent on UDP socket, instead of web sockets. Protocol is simple and same as bunyan: line delimited JSON.